### PR TITLE
Update room.go

### DIFF
--- a/baccaratServer/roomPkg/room.go
+++ b/baccaratServer/roomPkg/room.go
@@ -106,7 +106,7 @@ func (room *baseRoom) initialize(index int32, config RoomConfig) {
 	room._initUserPool()
 	room._userSessionUniqueIdMap = make(map[uint64]*roomUser)
 
-	room._gameLogic.clear()
+	room._gameLogic.init()
 }
 
 func (room *baseRoom) _initialize(index int32, config RoomConfig) {


### PR DESCRIPTION
baccaratGame._rand 가 초기화되지 않은 상태에서 clear 메소드를 호출하여 panic이 발생합니다.